### PR TITLE
Using os.path.splitext() to support Path objects

### DIFF
--- a/layeredimage/io/__init__.py
+++ b/layeredimage/io/__init__.py
@@ -1,7 +1,8 @@
 """Do file io."""
 from __future__ import annotations
 
-from os.path import exists
+from pathlib import Path
+from os.path import exists, splitext
 
 from ..layeredimage import LayeredImage
 from .gif import openLayer_GIF, saveLayer_GIF
@@ -29,7 +30,7 @@ def extNotRecognised(fileName: str):
 	)
 
 
-def openLayerImage(file: str) -> LayeredImage:
+def openLayerImage(file: str | Path) -> LayeredImage:
 	"""Open a layer image file into a layer image object.
 
 	Args:
@@ -58,14 +59,14 @@ def openLayerImage(file: str) -> LayeredImage:
 	if not exists(file):
 		print(f"ERROR: {file} does not exist")
 		raise FileExistsError
-	fileExt = file.split(".")[-1].lower()
+	fileExt = splitext(file)[1].lower()
 	if fileExt not in functionMap:
 		extNotRecognised(file)
 		raise ValueError
 	return functionMap[fileExt](file)
 
 
-def saveLayerImage(fileName: str, layeredImage: LayeredImage) -> None:
+def saveLayerImage(fileName: str | Path, layeredImage: LayeredImage) -> None:
 	"""Save a layered image to a file.
 
 	Args:
@@ -91,7 +92,7 @@ def saveLayerImage(fileName: str, layeredImage: LayeredImage) -> None:
 		"layered": saveLayer_LAYERED,
 		"layeredc": saveLayer_LAYEREDC,
 	}
-	fileExt = fileName.split(".")[-1].lower()
+	fileExt = splitext(file)[1].lower()
 	if fileExt not in functionMap:
 		extNotRecognised(fileName)
 		raise ValueError


### PR DESCRIPTION
Using os.path.splitext() is more robust than just str.split().

Additionally, it supports Path objects. Thus, this commit fixes this error:

AttributeError: 'PosixPath' object has no attribute 'split'

Note: it's my first time using type annotations, so it's likely I made some mistake. It is also relevant to add `| Path` to many other function/method signatures, but I'm not doing it in this commit. I leave this as an exercise/suggestion to the maintainer.

---

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [x] Bug fix
- [x] New feature
- [ ] Other (please explain):

### Overview of Changes

Using `os.path.splitext()` instead of `str.split()` makes the code accept both `str` and `Path` objects. What are such objects? Look at this example:

```python
BASE = "/tmp/foobar"
do_something(os.path.join(BASE, "hello.txt"))
```

Which is simpler due to the overridden `/` operator:

```python
BASE = Path("/tmp/foobar")
do_something(BASE / "hello.txt")
```

### Reviewer Focus

I wish you could test it to make sure I didn't make any mistake.

And I wish you to add other commits later (after this PR is merged) to add `Path` to more type annotations. I trust you know the codebase better than me, so I'll leave this to you.

### Additional Notes

This PR was created directly in the GitHub web interface.